### PR TITLE
3: Adding authentication interceptors instead of injecting the header…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,8 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
+
 import { AuthService, TokenService } from 'angular-aap-auth';
 import { ReactiveFormsModule } from '@angular/forms';
 import { JwtHelper } from 'angular2-jwt';
@@ -49,6 +51,9 @@ import {
 // Import Tests Classes.
 import { RouterLinkStubDirective, RouterOutletStubComponent } from './testing/router.stubs';
 
+// Import Interceptors.
+import { httpInterceptorProviders } from './http-interceptors/index';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -78,6 +83,7 @@ import { RouterLinkStubDirective, RouterOutletStubComponent } from './testing/ro
     BrowserModule,
     FormsModule,
     HttpModule,
+    HttpClientModule,
     AppRoutingModule,
     ReactiveFormsModule,
     LoadingModule.forRoot({
@@ -107,7 +113,8 @@ import { RouterLinkStubDirective, RouterOutletStubComponent } from './testing/ro
       useValue: {
         authURL: environment.authenticationHost
       }
-    }
+    },
+    httpInterceptorProviders
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/http-interceptors/auth-interceptor.ts
+++ b/src/app/http-interceptors/auth-interceptor.ts
@@ -3,7 +3,9 @@ import {
   HttpInterceptor, HttpHandler, HttpRequest
 } from '@angular/common/http';
 
+
 import { TokenService } from 'angular-aap-auth';
+import { environment } from 'environments/environment';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
@@ -11,7 +13,12 @@ export class AuthInterceptor implements HttpInterceptor {
   constructor(private tokenService: TokenService) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler) {
+    if (!req.url.startsWith(environment.apiHost)) {
+      return next.handle(req);
+    }
+
     // Get the auth token from the service.
+    // TODO: Replace the implementation of this lib with the new once.
     const authToken = this.tokenService.getToken();
 
     const authReq = req.clone(
@@ -23,7 +30,6 @@ export class AuthInterceptor implements HttpInterceptor {
         }
       }
     );
-
 
     // send cloned request with header to the next handler.
     return next.handle(authReq);

--- a/src/app/http-interceptors/auth-interceptor.ts
+++ b/src/app/http-interceptors/auth-interceptor.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpInterceptor, HttpHandler, HttpRequest
+} from '@angular/common/http';
+
+import { TokenService } from 'angular-aap-auth';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+
+  constructor(private tokenService: TokenService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler) {
+    // Get the auth token from the service.
+    const authToken = this.tokenService.getToken();
+
+    const authReq = req.clone(
+      {
+        setHeaders: {
+          Authorization:  "Bearer " + authToken,
+          ContentType : 'application/json',
+          Accept : 'application/hal+json, application/json',
+        }
+      }
+    );
+
+
+    // send cloned request with header to the next handler.
+    return next.handle(authReq);
+  }
+}

--- a/src/app/http-interceptors/index.ts
+++ b/src/app/http-interceptors/index.ts
@@ -1,0 +1,8 @@
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+
+import { AuthInterceptor } from './auth-interceptor';
+
+/** Http interceptor providers in outside-in order */
+export const httpInterceptorProviders = [
+  { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+];


### PR DESCRIPTION
Interceptors work well with HttpClient not with Http. This issue is more related to issue #4. Once we move to Angular 6 and use HttpClient, Interceptors should be applied automatically to all http requests. 